### PR TITLE
Generic for queue data and explicit types for hook usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,25 @@ function App() {
   );
 }
 ```
+
+```typescript
+import useQueue from "use-queue";
+
+function process(item: string, done: () => void) {
+  setTimeout(() => {
+    console.log("value of current queue item ==>", item);
+    done(); // we're finished processing the item and ready to remove it
+  }, 1000);
+}
+
+export function App() {
+  const [queue, add] = useQueue<string>(process);
+
+  return (
+    <div>
+      <code>{JSON.stringify(queue, null, 2)}</code>
+      <button onClick={() => add("Item Value Goes Here")}>Add To Queue</button>
+    </div>
+  );
+}
+```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useReducer } from "react";
 import { reducer, ReducerStateType } from "./reducer";
 
-type ProcessFnType = (item: any, done: () => void) => void;
+type ProcessFnType<T> = (item: T, done: () => void) => void;
 
-const useQueue = (process: ProcessFnType) => {
+const useQueue = <T extends unknown>(process: ProcessFnType<T>) => {
   const initialState: ReducerStateType = {
     isProcessing: false,
     queue: [],
   };
   const [{ isProcessing, queue }, dispatch] = useReducer(reducer, initialState);
 
-  function add(payload: any) {
+  function add(payload: T) {
     dispatch({
       type: "ADD",
       payload,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,9 @@ import { reducer, ReducerStateType } from "./reducer";
 
 type ProcessFnType<T> = (item: T, done: () => void) => void;
 
-const useQueue = <T extends unknown>(process: ProcessFnType<T>) => {
+const useQueue = <T extends unknown>(
+  process: ProcessFnType<T>
+): [T[], (payload: T) => void] => {
   const initialState: ReducerStateType = {
     isProcessing: false,
     queue: [],


### PR DESCRIPTION
Generic will help to strictly define types for a queue and it's a common pattern to explicitly return data from a hook (https://github.com/microsoft/TypeScript/issues/11312)